### PR TITLE
Fix link to domain configuration in docs

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -111,7 +111,7 @@
 
             <a href="/dokku/configuration-management/" class="list-group-item">Environment Variables</a>
             <a href="/dokku/dns/" class="list-group-item">DNS Configuration</a>
-            <a href="/dokku/deployment/domains/" class="list-group-item">Domain Configuration</a>
+            <a href="/dokku/deployment/domain-configuration/" class="list-group-item">Domain Configuration</a>
             <a href="/dokku/nginx/" class="list-group-item">Nginx Configuration</a>
             <a href="/dokku/deployment/ssl-configuration/" class="list-group-item">SSL Configuration</a>
             <a href="/dokku/dokku-events-logs/" class="list-group-item">Dokku Event Logs</a>


### PR DESCRIPTION
When `domains.md` was moved to `domain-configuration.md` this link was not updated.